### PR TITLE
Change setup script to Python 3 shebang

### DIFF
--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pip
 from shutil import copyfile, which


### PR DESCRIPTION
If you're following recommendations in the [CONTRIBUTING.md](https://github.com/datasciencebr/serenata-de-amor/blob/master/CONTRIBUTING.md#environment), will correctly point to `~/anaconda3/envs/serenata_de_amor/bin/python3`. Otherwise, will at least use Python 3 if available in the system.

Fixes #59.