### PR TITLE
Incluindo trecho traduzido do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,21 @@ To achieve this goal, unprecedented, we invite everyone to train the intelligenc
 ## License
 
 The project Operation Serenata de Amor is available under [MIT license](LICENSE).
+
+# Em Português
+
+A Operação Serenata de Amor surgiu a partir de uma combinação de necessidades, de muitas pessoas, de muitas nacionalidades: de ver Aprendizagem de Máquina sendo melhor aplicada para melhorar a vida da população, aprender em quem votar, fazer algo sobre problemas de corrupção presentes no mundo todo.
+
+Estamos construindo uma inteligência capaz de analisar a despesa pública e sinalizando, com segurança, a possibilidade do recibo fiscal ser ilegal. Esta informação será usada para além do código, no mundo fora do GitHub. Tudo é código aberto desde o início, permitindo que outros bifurquem o projeto quando suas ideias divergirem da Operação Serenata de Amor.
+
+Nosso estágio atual está em criar os meios para esse tipo de automação sobre dados da Cota de Exercício de Atividade Parlamentar (CEAP), da Câmara dos Deputados do Brasil. Este trabalho inclui o desenvolvimento de APIs, limpeza de dados e análises, concepção e validação de hipóteses científicas, a confirmação de atos ilícitos através de investigações e relatos - à população e às autoridades legais.
+
+Para alcançar este objetivo, sem precedentes, convidamos todos a treinar a inteligência, coletar informações, cruzar bases de dados, validar hipóteses e aplicar Aprendizarem de Máquina com modelos competindo entre si e sendo combinados em conjunto com uma maior precisão do que qualquer das opções anteriores.
+
+## Antes de contribuir
+
+**[Visit o site web oficial](http://serenata.datasciencebr.com/)** e lembre de ler **[o guia de contribuição (apenas em inglês)](/CONTRIBUTING.md)** se você pretende ajudar na parte de software.
+
+## Licença
+
+O Projeto Operação Serenata de Amor está disponível sob a licença [MIT license](LICENSE).


### PR DESCRIPTION
Incluí o texto do README em portugês ao final do documento. Apoio a prioridade no uso da língua inglesa para desenvolvimento de softwares em geral. Amplifica o alcance e disseminação do software. Todavia, pelo caráter social do projeto, vejo como interessante que pelo menos esta parte do software consiga ser apropriado por pessoas que só lêm em português.