### PR TITLE
Add pandas>=0.18.1 to requirements

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.4.1
 geopy==1.11.0
 humanize==0.5.1
+pandas>=0.18.1
 seaborn==0.7.1


### PR DESCRIPTION
The ‘xz’ compression, that is being used in the datasets, was introduced in pandas version 0.18.1.