### PR TITLE
Upgrade auto-conversion hook to remove deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,8 @@ def post_save(model, os_path, contents_manager):
     if model['type'] != 'notebook':
         return # only do this for notebooks
     d, fname = os.path.split(os_path)
-    check_call(['ipython', 'nbconvert', '--to', 'script', fname], cwd=d)
-    check_call(['ipython', 'nbconvert', '--to', 'html', fname], cwd=d)
+    check_call(['jupyter', 'nbconvert', '--to', 'script', fname], cwd=d)
+    check_call(['jupyter', 'nbconvert', '--to', 'html', fname], cwd=d)
 
 c.FileContentsManager.post_save_hook = post_save
 ```


### PR DESCRIPTION
The current hook proposed in the best practices section of
CONTRIBUTING.md to auto-convert notebooks to .py and .html formats
has a slightly minor problem: it uses a deprecated command, as stated
in the stdout every time the hook gets called:

```
[TerminalIPythonApp] WARNING | Subcommand `ipython nbconvert` is
deprecated and will be removed in future versions.
[TerminalIPythonApp] WARNING | You likely want to use `jupyter
nbconvert` in the future
```

This PR fix the recommendation, orientating users to use the new
approach (jupyter nbconvert) instead of the old one. There should not
be any side effects.