### PR TITLE
Docker dev environment tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ $ source /usr/local/var/pyenv/versions/anaconda3-4.1.1/bin/activate serenata_de_
 
 You can user [Docker](https://docs.docker.com/engine/installation/) and [Docker Compose](https://docs.docker.com/compose/install/) to have a working environment:
 
-1. Start the environment (it might take a while, the base image has 5.3GB and we also pull in lots of dependencies): `$ docker-compose up -d`
+1. Start the environment (it might take a while, the base image has 5.8GB and we also pull in lots of dependencies): `$ docker-compose up -d`
 1. Create your `config.ini` file from the example: `$ cp config.ini.example config.ini`
 1. Run the script to download data and other useful files: `$ docker-compose run --rm jupyter python src/fetch_datasets.py`
 1. You can start Jupyter Notebooks and access them at [localhost:8888](http://localhost:8888): `$ docker-compose run --rm jupyter jupyter notebook`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:latest
+FROM jupyter/datascience-notebook:fa77fe99579b
 MAINTAINER Serenata de Amor "datasciencebr@gmail.com"
 
 USER root

--- a/docker/jupyter_notebook_config.py
+++ b/docker/jupyter_notebook_config.py
@@ -36,6 +36,9 @@ if 'USE_HTTPS' in os.environ:
         os.chmod(PEM_FILE, stat.S_IRUSR | stat.S_IWUSR)
     c.NotebookApp.certfile = PEM_FILE
 
+# Disable authentication altogether, NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS
+c.NotebookApp.token = ''
+
 ### If you want to auto-save .html and .py versions of your notebook:
 # modified from: https://github.com/ipython/ipython/issues/8009
 def post_save(model, os_path, contents_manager):

--- a/docker/jupyter_notebook_config.py
+++ b/docker/jupyter_notebook_config.py
@@ -36,12 +36,6 @@ if 'USE_HTTPS' in os.environ:
         os.chmod(PEM_FILE, stat.S_IRUSR | stat.S_IWUSR)
     c.NotebookApp.certfile = PEM_FILE
 
-# Set a password if PASSWORD is set
-if 'PASSWORD' in os.environ:
-    from IPython.lib import passwd
-    c.NotebookApp.password = passwd(os.environ['PASSWORD'])
-    del os.environ['PASSWORD']
-
 ### If you want to auto-save .html and .py versions of your notebook:
 # modified from: https://github.com/ipython/ipython/issues/8009
 def post_save(model, os_path, contents_manager):


### PR DESCRIPTION
Follow up of a discussion over Telegram, this PR:

- Locks the docker image to a known to work tag for reproducibility
- Updates contributing info with the size of the image in use
- Disables authentication altogether (the OP on Telegram mentioned he had issues with the token that was generated for him). I don't think this is an issue since this is not meant to be used in production AFAIK.

/cc @cuducos 