### PR TITLE
Add dockerignore to prevent upload of data dir and other files to docker engine on builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*.pyc
+.ipynb_checkpoints
+.python-version
+__pycache__/
+config.ini
+data
+.idea/
+serenata-de-amor.iml


### PR DESCRIPTION
This prevents files under `data/` and other stuff that is gitignored from being added as the context of docker builds.

This is a problem since (for example) I've just downloaded 5Gb worth of PDF receipts into that dir and when I had to rebuild my env the `docker-compose` command became unresponsive and builds where taking waaaaay too long to complete (I really wish docker defaulted to looking up gitignores but that's not the case)

/cc @cuducos @gomex