### PR TITLE
Allow src/clean_cnpj_info_dataset.py scripts to receive data files as cli args

### DIFF
--- a/src/clean_cnpj_info_dataset.py
+++ b/src/clean_cnpj_info_dataset.py
@@ -16,10 +16,10 @@ parser.add_option("--companies", dest="companies", metavar="FILE",
 (options, args) = parser.parse_args()
 
 if options['cnpj_cpf']:
-    CNPJ_CPF_CSV_PATH = os.path.join('data', 'cnpj-info.xz')
+    CNPJ_CPF_CSV_PATH = options['cnpj_cpf']
 
 if options['companies']:
-    COMPANIES_CSV_PATH = os.path.join('data', 'companies.xz')
+    COMPANIES_CSV_PATH = options['companies']
 
 no_named_args = (not options['cnpj_cpf']) and (not options['companies'])
 

--- a/src/clean_cnpj_info_dataset.py
+++ b/src/clean_cnpj_info_dataset.py
@@ -3,6 +3,35 @@ import numpy as np
 import os
 import pandas as pd
 
+from optparse import OptionParser
+
+CNPJ_CPF_CSV_PATH = os.path.join('data', 'cnpj-info.xz')
+COMPANIES_CSV_PATH = os.path.join('data', 'companies.xz')
+
+parser = OptionParser()
+parser.add_option("--cnpj", dest="cnpj_cpf", metavar="FILE",
+                  help="file to read the cnpj/cpf from")
+parser.add_option("--companies", dest="companies", metavar="FILE",
+                  help="file to read the companies from")
+(options, args) = parser.parse_args()
+
+if options['cnpj_cpf']:
+    CNPJ_CPF_CSV_PATH = os.path.join('data', 'cnpj-info.xz')
+
+if options['companies']:
+    COMPANIES_CSV_PATH = os.path.join('data', 'companies.xz')
+
+no_named_args = (not options['cnpj_cpf']) and (not options['companies'])
+
+if no_named_args and len(args) == 2:
+    CNPJ_CPF_CSV_PATH, COMPANIES_CSV_PATH = args
+elif no_named_args and len(args) != 2:
+    print("The script expects to either receive named args or")
+    print("two unnamed args, falling to default values")
+elif not os.path.exists(CNPJ_CPF_CSV_PATH):
+    print("No file found at {}, falling to default.".format(CNPJ_CPF_CSV_PATH))
+
+
 def decompose_main_activity(value):
     struct = json.loads(value.replace('\'', '"'))
     if struct:
@@ -24,7 +53,7 @@ def decompose_secondary_activities(value):
 
 
 
-data = pd.read_csv(os.path.join('data', 'cnpj-info.xz'),
+data = pd.read_csv(CNPJ_CPF_CSV_PATH,
                    dtype={'atividade_principal': np.str,
                           'atividades_secundarias': np.str,
                           'complemento': np.str,
@@ -81,7 +110,7 @@ data = pd.concat([
     data['secondary_activities'].apply(decompose_secondary_activities)],
     axis=1)
 
-data.to_csv(os.path.join('data', 'companies.xz'),
+data.to_csv(COMPANIES_CSV_PATH,
             compression='xz',
             encoding='utf-8',
             index=False)


### PR DESCRIPTION
As specified in [#167](https://github.com/datasciencebr/serenata-de-amor/issues/167), some scripts in src/ didn't accepted command line arguments, this adds an option to pass file arguments to the src/clean_cnpj_info_dataset.py. It treats arguments in the following way: if you pass two unnamed args to it, the first will be treated as the cnpj_cpf.xz file, and the second as the companies.xz file, you can also pass named arguments, using the --cnpj and --companies flags.