### PR TITLE
Ignore HTML and PY files in Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/develop/*.html linguist-generated=true
+/develop/*.py linguist-generated=true


### PR DESCRIPTION
It will make the repository be better classified in the expected languages
on GitHub.

I expect to change the classification for something better describes the contents of the repo, making it a project made of Jupyter Notebooks.

<img width="997" alt="screen shot 2017-07-23 at 00 59 41" src="https://user-images.githubusercontent.com/667753/28494831-b7f3ebc8-6f42-11e7-9b99-66b8e7c6af3d.png">

Docs:
https://github.com/github/linguist/tree/b94e018c3af1ca5b3858f2249253d076b26df6a0#generated-code