### PR TITLE
Fix Docker install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,9 +72,9 @@ $ source /usr/local/var/pyenv/versions/anaconda3-4.1.1/bin/activate serenata_de_
 
 You can user [Docker](https://docs.docker.com/engine/installation/) and [Docker Compose](https://docs.docker.com/compose/install/) to have a working environment:
 
-1. Start the environment (it might take a while, the base image has 6.88GB and we also pull in lots of dependencies): `$ docker-compose up -d`.
 1. Create your `config.ini` file from the example: `$ cp config.ini.example config.ini`
-1. Run the script to download data and other useful files: `$ docker-compose run --rm research python src/fetch_datasets.py`
+1. Build the tags with `$ docker-compose build`
+1. Start the environment (it might take a while, hurry not): `$ docker-compose up -d`.
 1. You can start Jupyter Notebooks and access them at [localhost:8888](http://localhost:8888): `$ docker-compose run --rm research jupyter notebook`
 
 If you want to access the console:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3"
 services:
   research:
     build:
-      context: research
+      context: ./
+      dockerfile: research/Dockerfile
     ports:
       - 8888:8888
     volumes:

--- a/research/Dockerfile
+++ b/research/Dockerfile
@@ -1,20 +1,24 @@
-FROM jupyter/datascience-notebook:bb222f49222e
+FROM jupyter/datascience-notebook:8f56e3c47fec
 MAINTAINER Serenata de Amor "datasciencebr@gmail.com"
 
 USER root
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-                       unzip \
-                       libxml2-dev \
-                       libxslt-dev \
+        unzip \
+        libxml2-dev \
+        libxslt-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt ./
-RUN pip install --upgrade pip \
-    && pip install -r requirements.txt
-
 USER jovyan
 
-COPY jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py
+COPY ./research/requirements.txt ./requirements.txt
+COPY ./config.ini ./config.ini
+COPY ./setup ./setup
+
+RUN conda update setuptools
+RUN pip install -r requirements.txt
+RUN ./setup
+
+COPY ./research/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py

--- a/research/requirements.txt
+++ b/research/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/marcusrehm/neo4jupyter.git@master
+git+https://github.com/marcusrehm/neo4jupyter.git@master
 aiofiles==0.3.0
 aiohttp==1.3.1
 beautifulsoup4==4.6.0

--- a/setup
+++ b/setup
@@ -4,9 +4,14 @@ import os
 import pip
 from shutil import copyfile, which
 
-copyfile('config.ini.example', 'config.ini')
+if not os.path.exists('config.ini'):
+    copyfile('config.ini.example', 'config.ini')
 
-pip.main(['install', '--upgrade', '-r', 'research/requirements.txt'])
+requirements = os.path.join('research', 'requirements.txt')  # local install
+if not os.path.exists(requirements):
+    requirements = 'requirements.txt'  # Docker
+
+pip.main(['install', '--upgrade', '-r', requirements])
 
 if which('unzip') == None:
     print('The following executables are needed and were not found: unzip')


### PR DESCRIPTION
This PR fixes three bugs in the Docker install files and instructions:

* `config.ini` wasn't available inside `research` Docker conatiner causing `seretana_toolbox` to fail
* Docker instructions depended on a deprecated script (`src/fetch_datasets.py`)
* In addition it run `setup` script by default during the Docker container build (fixing the previous bullet point and somehow _testing_ the first bullet point)

**Disclaimer:** as titled and labeled this is a _work in progress_. I coded that in a bus and pushed it using 3G — but I haven't tested it yet. Gonna test (and probably fix whatever I got wrong in the infamous _brain code compiler_ as soon as I reach civilization and wifi).