### PR TITLE
Add option to download all datasets from serenata-toolbox

### DIFF
--- a/setup
+++ b/setup
@@ -2,12 +2,17 @@
 
 import os
 import pip
+import argparse
 from shutil import copyfile, which
-
 
 RESEARCH_DIR = 'research'
 DATA_DIR = os.path.join(RESEARCH_DIR, 'data')
 
+parser = argparse.ArgumentParser(description='Setup serenata-de-amor using serenata-toolbox.')
+parser.add_argument('--all', dest='all', action='store_true',
+                    help='Force all datasets from serenata-toolbox to be downloaded')
+
+args = parser.parse_args()
 
 if not os.path.exists('config.ini'):
     copyfile('config.ini.example', 'config.ini')
@@ -26,4 +31,4 @@ print('Downloading datasets (this might take several minutes depending on your i
 # This is imported here because serenata_toolbox is only installed when pip.main is called (line 9)
 from serenata_toolbox.datasets import fetch_latest_backup
 os.makedirs(DATA_DIR, exist_ok=True)
-fetch_latest_backup(DATA_DIR)
+fetch_latest_backup(DATA_DIR, force_all=args.all)

--- a/setup
+++ b/setup
@@ -8,9 +8,12 @@ from shutil import copyfile, which
 RESEARCH_DIR = 'research'
 DATA_DIR = os.path.join(RESEARCH_DIR, 'data')
 
-parser = argparse.ArgumentParser(description='Setup serenata-de-amor using serenata-toolbox.')
+parser = argparse.ArgumentParser(
+    description='Setup serenata-de-amor using serenata-toolbox.')
+
 parser.add_argument('--all', dest='all', action='store_true',
-                    help='Force all datasets from serenata-toolbox to be downloaded')
+                    help='Force all datasets from serenata-toolbox \
+                    to be downloaded')
 
 args = parser.parse_args()
 
@@ -26,9 +29,11 @@ pip.main(['install', '--upgrade', '-r', requirements])
 if which('unzip') is None:
     print('The following executables are needed and were not found: unzip')
 
-print('Downloading datasets (this might take several minutes depending on your internet connection)')
+print('Downloading datasets (this might take several minutes \
+    depending on your internet connection)')
 
-# This is imported here because serenata_toolbox is only installed when pip.main is called (line 9)
+# This is imported here because serenata_toolbox is only
+# installed when pip.main is called (line 27)
 from serenata_toolbox.datasets import fetch_latest_backup
 os.makedirs(DATA_DIR, exist_ok=True)
 fetch_latest_backup(DATA_DIR, force_all=args.all)

--- a/setup
+++ b/setup
@@ -18,7 +18,7 @@ if not os.path.exists(requirements):
 
 pip.main(['install', '--upgrade', '-r', requirements])
 
-if which('unzip') == None:
+if which('unzip') is None:
     print('The following executables are needed and were not found: unzip')
 
 print('Downloading datasets (this might take several minutes depending on your internet connection)')


### PR DESCRIPTION
This PR depends on https://github.com/datasciencebr/serenata-toolbox/pull/133

If the user wants to download all the datasets from serenata-toolbox, he can pass an option to the command `./setup`. Usage: `./setup --all`.