### PR TITLE
#276 - Fixed error on editing Jupyter notebook

### DIFF
--- a/research/Dockerfile
+++ b/research/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update \
         libxml2-dev \
         libxslt-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && sudo -u jovyan mkdir /home/jovyan/.jupyter
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sudo -u jovyan mkdir /home/jovyan/.jupyter
 
 USER jovyan
 

--- a/research/Dockerfile
+++ b/research/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
         libxml2-dev \
         libxslt-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && sudo -u jovyan mkdir /home/jovyan/.jupyter
 
 USER jovyan
 


### PR DESCRIPTION
Bug:
  Given serenata-de-amor cloned from github, built by docker-compose and up by docker-compose
  When editing a Jupyter notebook from directory work/develop
  Then causes "PermissionError: [Errno 13] Permission denied: '/home/jovyan/.jupyter/migrated'"

Bug analysis:
  Directory /home/jovyan/.jupyter with owner root and jupyter process with owner jovyan

Root cause:
  COPY command of Docker creates files and directories with a UID and GID of 0, according to [documentation](https://docs.docker.com/engine/reference/builder/#copy) and pointed on this [thread](https://stackoverflow.com/questions/44766665/how-do-i-docker-copy-as-non-root).

Solution:
  Setting owner jovyan for directory /home/jovyan/.jupyter