### PR TITLE
Remove tinys3

### DIFF
--- a/research/requirements.txt
+++ b/research/requirements.txt
@@ -17,5 +17,4 @@ pycpfcnpj==1.3
 scikit-learn==0.19.1
 seaborn==0.8.1
 serenata-toolbox # pyup: ignore
-tinys3==0.1.12
 tqdm==4.19.5


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

All Amazon S3 handling is done by `serenata-toolbox` so we don't need `tinys3` anymore.

**What was done to achieve this purpose?**

Just a tiny cleanup on `requirements.txt`: I removed `tinys3` line.

**How to test if it really works?**

Hum… some options:

1. From a fresh install try every script and check they don't break
2. From an existing install `pip uninstall tinys3`, try every script and check they don't break
3. Just check every script to make sure `tinys3` is never called or imported (GitHub search, `grep`, [`ag`](https://github.com/ggreer/the_silver_searcher) or [`ack`](https://beyondgrep.com/) might be your friend)

**Who can help reviewing it?**

@anaschwendler 