### PR TITLE
Enlarge droplet to 64GB RAM to avoid memory error

### DIFF
--- a/contrib/update/update.yml
+++ b/contrib/update/update.yml
@@ -17,7 +17,7 @@
         image_id: ubuntu-18-04-x64
         name: serenata-update
         region_id: nyc1
-        size_id: s-8vcpu-32gb
+        size_id: s-16vcpu-64gb
         unique_name: yes
         ssh_key_ids:
           - "{{ ssh_public_key.ssh_key.id | int }}"


### PR DESCRIPTION
When running the `/contrib/crontab/update` task, the `TraveledSpeedsClassifier` was raising `MemoryError` in it's `predict` method (line 70).

This is a temporary solve. We should investigate if this memory consumption can be reduced.

This issue is further described in #560.

Fixes:
#556 